### PR TITLE
Secondary sorting by user id

### DIFF
--- a/src/components/points/includes/points.php
+++ b/src/components/points/includes/points.php
@@ -1172,7 +1172,7 @@ function wordpoints_points_get_top_users( $num_users, $points_type ) {
                         AND `meta`.`meta_key` = %s
 					{$multisite_join}
                     {$exclude_users}
-					ORDER BY COALESCE(CONVERT(`meta`.`meta_value`, SIGNED INTEGER), 0) DESC
+					ORDER BY COALESCE(CONVERT(`meta`.`meta_value`, SIGNED INTEGER), 0) DESC, `ID` ASC
 					LIMIT %d,%d
 				",
 				wordpoints_get_points_user_meta_key( $points_type ),


### PR DESCRIPTION
Fixes the sorting within groups of users with the same amount of points, which didn't appear to make any sense and would change in a seemingly random fashion on cache expires.