### PR TITLE
fix: Multisite: use get_current_blog_id() instead of $wpdb->blogid

### DIFF
--- a/src/components/points/includes/class-wordpoints-points-logs-query.php
+++ b/src/components/points/includes/class-wordpoints-points-logs-query.php
@@ -162,7 +162,7 @@ class WordPoints_Points_Logs_Query extends WordPoints_DB_Query {
 	 *        @type string       $text__compare       Comparison operator for $text. May be any of these:  '=', '<>', '!=', 'LIKE', 'NOT LIKE'. Default is 'LIKE'.
 	 *        @type string[]     $text__in            Return only logs with these texts.
 	 *        @type string[]     $text__not_in        Exclude logs with these texts from the results.
-	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is $wpdb->blogid (current blog).
+	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is get_current_blog_id() (current blog).
 	 *        @type string       $blog_id__compare    Comparison operator for $text. May be any of these:  '=', '<>', '!=', 'LIKE', 'NOT LIKE'. Default is 'LIKE'.
 	 *        @type int[]        $blog_id__in         Limit results to these blogs.
 	 *        @type int[]        $blog_id__not_in     Exclude these blogs.

--- a/src/components/points/includes/class-wordpoints-points-logs-query.php
+++ b/src/components/points/includes/class-wordpoints-points-logs-query.php
@@ -162,7 +162,7 @@ class WordPoints_Points_Logs_Query extends WordPoints_DB_Query {
 	 *        @type string       $text__compare       Comparison operator for $text. May be any of these:  '=', '<>', '!=', 'LIKE', 'NOT LIKE'. Default is 'LIKE'.
 	 *        @type string[]     $text__in            Return only logs with these texts.
 	 *        @type string[]     $text__not_in        Exclude logs with these texts from the results.
-	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is get_current_blog_id() (current blog).
+	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is the current blog (or 0 if not on multisite).
 	 *        @type string       $blog_id__compare    Comparison operator for $text. May be any of these:  '=', '<>', '!=', 'LIKE', 'NOT LIKE'. Default is 'LIKE'.
 	 *        @type int[]        $blog_id__in         Limit results to these blogs.
 	 *        @type int[]        $blog_id__not_in     Exclude these blogs.

--- a/src/components/points/includes/functions.php
+++ b/src/components/points/includes/functions.php
@@ -297,7 +297,7 @@ function wordpoints_delete_points_logs_for_user( $user_id ) {
 	$where = array( 'user_id' => $user_id );
 
 	if ( ! isset( $query_args['blog_id'] ) ) {
-		$where['blog_id'] = get_current_blog_id();
+		$where['blog_id'] = is_multisite() ? get_current_blog_id() : '0';
 	}
 
 	// Now delete the logs.

--- a/src/components/points/includes/functions.php
+++ b/src/components/points/includes/functions.php
@@ -297,7 +297,7 @@ function wordpoints_delete_points_logs_for_user( $user_id ) {
 	$where = array( 'user_id' => $user_id );
 
 	if ( ! isset( $query_args['blog_id'] ) ) {
-		$where['blog_id'] = $wpdb->blogid;
+		$where['blog_id'] = get_current_blog_id();
 	}
 
 	// Now delete the logs.

--- a/src/components/points/includes/points.php
+++ b/src/components/points/includes/points.php
@@ -624,7 +624,7 @@ function wordpoints_alter_points( $user_id, $points, $points_type, $log_type, $m
 				'text'        => $log_text,
 				'date'        => current_time( 'mysql', 1 ),
 				'site_id'     => $wpdb->siteid,
-				'blog_id'     => $wpdb->blogid,
+				'blog_id'     => get_current_blog_id(),
 			),
 			array( '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d' )
 		);

--- a/src/components/points/includes/points.php
+++ b/src/components/points/includes/points.php
@@ -624,7 +624,7 @@ function wordpoints_alter_points( $user_id, $points, $points_type, $log_type, $m
 				'text'        => $log_text,
 				'date'        => current_time( 'mysql', 1 ),
 				'site_id'     => $wpdb->siteid,
-				'blog_id'     => get_current_blog_id(),
+				'blog_id'     => is_multisite() ? get_current_blog_id() : '0',
 			),
 			array( '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d' )
 		);
@@ -1091,7 +1091,7 @@ function wordpoints_points_get_top_users( $num_users, $points_type ) {
 		$multisite_join = '';
 		if ( is_multisite() && ! is_wordpoints_network_active() ) {
 
-			$prefix = $wpdb->get_blog_prefix( get_current_blog_id() );
+			$prefix = $wpdb->get_blog_prefix( is_multisite() ? get_current_blog_id() : '0' );
 
 			$multisite_join = "
 					INNER JOIN `{$wpdb->usermeta}` AS `cap`

--- a/src/components/ranks/classes/ranks/updater/2/4/0/user/ranks.php
+++ b/src/components/ranks/classes/ranks/updater/2/4/0/user/ranks.php
@@ -37,7 +37,7 @@ class WordPoints_Ranks_Updater_2_4_0_User_Ranks implements WordPoints_RoutineI {
 						AND `blog_id` = %d
 						AND `site_id` = %d
 				"
-				, get_current_blog_id()
+				, is_multisite() ? get_current_blog_id() : '0'
 				, $wpdb->siteid
 			)
 		);

--- a/src/components/ranks/classes/ranks/updater/2/4/0/user/ranks.php
+++ b/src/components/ranks/classes/ranks/updater/2/4/0/user/ranks.php
@@ -37,7 +37,7 @@ class WordPoints_Ranks_Updater_2_4_0_User_Ranks implements WordPoints_RoutineI {
 						AND `blog_id` = %d
 						AND `site_id` = %d
 				"
-				, $wpdb->blogid
+				, get_current_blog_id()
 				, $wpdb->siteid
 			)
 		);

--- a/src/components/ranks/classes/user/ranks/query.php
+++ b/src/components/ranks/classes/user/ranks/query.php
@@ -74,7 +74,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 	 *        @type string       $rank_group__compare The comparison operator to use with the above value.
 	 *        @type string[]     $rank_group__in      A list of rank groups to query for.
 	 *        @type string[]     $rank_group__not_in  A list of rank groups to exclude.
-	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is $wpdb->blogid (current blog).
+	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is get_current_blog_id() (current blog).
 	 *        @type string       $blog_id__compare    Comparison operator for the above value.
 	 *        @type int[]        $blog_id__in         Limit results to these blogs.
 	 *        @type int[]        $blog_id__not_in     Exclude these blogs.
@@ -97,7 +97,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 
 		$this->table_name = $wpdb->wordpoints_user_ranks;
 
-		$this->defaults['blog_id'] = $wpdb->blogid;
+		$this->defaults['blog_id'] = get_current_blog_id();
 		$this->defaults['site_id'] = $wpdb->siteid;
 
 		parent::__construct( $args );
@@ -207,7 +207,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 				"
 				, $rank->ID
 				, $rank->rank_group
-				, $wpdb->blogid
+				, get_current_blog_id()
 				, $wpdb->siteid
 				, $rank->rank_group
 			)

--- a/src/components/ranks/classes/user/ranks/query.php
+++ b/src/components/ranks/classes/user/ranks/query.php
@@ -74,7 +74,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 	 *        @type string       $rank_group__compare The comparison operator to use with the above value.
 	 *        @type string[]     $rank_group__in      A list of rank groups to query for.
 	 *        @type string[]     $rank_group__not_in  A list of rank groups to exclude.
-	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is get_current_blog_id() (current blog).
+	 *        @type int          $blog_id             Limit results to those from this blog within the network (multisite). Default is the current blog (or 0 if not on multisite).
 	 *        @type string       $blog_id__compare    Comparison operator for the above value.
 	 *        @type int[]        $blog_id__in         Limit results to these blogs.
 	 *        @type int[]        $blog_id__not_in     Exclude these blogs.
@@ -97,7 +97,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 
 		$this->table_name = $wpdb->wordpoints_user_ranks;
 
-		$this->defaults['blog_id'] = get_current_blog_id();
+		$this->defaults['blog_id'] = is_multisite() ? get_current_blog_id() : '0';
 		$this->defaults['site_id'] = $wpdb->siteid;
 
 		parent::__construct( $args );
@@ -207,7 +207,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 				"
 				, $rank->ID
 				, $rank->rank_group
-				, get_current_blog_id()
+				, is_multisite() ? get_current_blog_id() : '0'
 				, $wpdb->siteid
 				, $rank->rank_group
 			)

--- a/src/components/ranks/includes/ranks.php
+++ b/src/components/ranks/includes/ranks.php
@@ -55,7 +55,7 @@ function wordpoints_add_rank( $name, $type, $group, $position, array $meta = arr
 			'name'       => $name,
 			'type'       => $type,
 			'rank_group' => $group,
-			'blog_id'    => get_current_blog_id(),
+			'blog_id'    => is_multisite() ? get_current_blog_id() : '0',
 			'site_id'    => $wpdb->siteid,
 		)
 	);
@@ -481,7 +481,7 @@ function wordpoints_get_user_rank( $user_id, $group ) {
 				"
 				, $user_id
 				, $group
-				, get_current_blog_id()
+				, is_multisite() ? get_current_blog_id() : '0'
 				, $wpdb->siteid
 			)
 		);
@@ -558,7 +558,7 @@ function wordpoints_update_user_rank( $user_id, $rank_id ) {
 			"
 				INSERT INTO `{$wpdb->wordpoints_user_ranks}`
 					(`user_id`, `rank_id`, `rank_group`, `blog_id`, `site_id`)
-				VALUES 
+				VALUES
 					(%d, %d, %s, %d, %d)
 				ON DUPLICATE KEY
 					UPDATE `rank_id` = %d
@@ -566,7 +566,7 @@ function wordpoints_update_user_rank( $user_id, $rank_id ) {
 			, $user_id
 			, $rank_id
 			, $rank->rank_group
-			, get_current_blog_id()
+			, is_multisite() ? get_current_blog_id() : '0'
 			, $wpdb->siteid
 			, $rank_id
 		)
@@ -637,7 +637,7 @@ function wordpoints_update_users_to_rank( array $user_ids, $to_rank_id, $from_ra
 		', %d, %s, %d, %d'
 		, $to_rank_id
 		, $rank->rank_group
-		, get_current_blog_id()
+		, is_multisite() ? get_current_blog_id() : '0'
 		, $wpdb->siteid
 	);
 
@@ -646,7 +646,7 @@ function wordpoints_update_users_to_rank( array $user_ids, $to_rank_id, $from_ra
 			"
 				INSERT INTO `{$wpdb->wordpoints_user_ranks}`
 					(`user_id`, `rank_id`, `rank_group`, `blog_id`, `site_id`)
-				VALUES 
+				VALUES
 					(" . implode( array_map( 'absint', $user_ids ), "{$prepared}),\n\t\t\t\t\t(" ) . "{$prepared})
 				ON DUPLICATE KEY
 					UPDATE `rank_id` = %d
@@ -804,7 +804,7 @@ function wordpoints_set_new_user_ranks( $user_id ) {
 					"
 						INSERT INTO `{$wpdb->wordpoints_user_ranks}`
 							(`user_id`, `rank_id`, `rank_group`, `blog_id`, `site_id`)
-						VALUES 
+						VALUES
 							(%d, %d, %s, %d, %d)
 						ON DUPLICATE KEY
 							UPDATE `rank_id` = %d
@@ -812,7 +812,7 @@ function wordpoints_set_new_user_ranks( $user_id ) {
 					, $user_id
 					, $base_rank->ID
 					, $base_rank->rank_group
-					, get_current_blog_id()
+					, is_multisite() ? get_current_blog_id() : '0'
 					, $wpdb->siteid
 					, $base_rank->ID
 				)
@@ -839,7 +839,7 @@ function wordpoints_delete_user_ranks( $user_id ) {
 		$wpdb->wordpoints_user_ranks
 		, array(
 			'user_id' => $user_id,
-			'blog_id' => get_current_blog_id(),
+			'blog_id' => is_multisite() ? get_current_blog_id() : '0',
 			'site_id' => $wpdb->siteid,
 		)
 		, '%d'

--- a/src/components/ranks/includes/ranks.php
+++ b/src/components/ranks/includes/ranks.php
@@ -55,7 +55,7 @@ function wordpoints_add_rank( $name, $type, $group, $position, array $meta = arr
 			'name'       => $name,
 			'type'       => $type,
 			'rank_group' => $group,
-			'blog_id'    => $wpdb->blogid,
+			'blog_id'    => get_current_blog_id(),
 			'site_id'    => $wpdb->siteid,
 		)
 	);
@@ -481,7 +481,7 @@ function wordpoints_get_user_rank( $user_id, $group ) {
 				"
 				, $user_id
 				, $group
-				, $wpdb->blogid
+				, get_current_blog_id()
 				, $wpdb->siteid
 			)
 		);
@@ -566,7 +566,7 @@ function wordpoints_update_user_rank( $user_id, $rank_id ) {
 			, $user_id
 			, $rank_id
 			, $rank->rank_group
-			, $wpdb->blogid
+			, get_current_blog_id()
 			, $wpdb->siteid
 			, $rank_id
 		)
@@ -637,7 +637,7 @@ function wordpoints_update_users_to_rank( array $user_ids, $to_rank_id, $from_ra
 		', %d, %s, %d, %d'
 		, $to_rank_id
 		, $rank->rank_group
-		, $wpdb->blogid
+		, get_current_blog_id()
 		, $wpdb->siteid
 	);
 
@@ -812,7 +812,7 @@ function wordpoints_set_new_user_ranks( $user_id ) {
 					, $user_id
 					, $base_rank->ID
 					, $base_rank->rank_group
-					, $wpdb->blogid
+					, get_current_blog_id()
 					, $wpdb->siteid
 					, $base_rank->ID
 				)
@@ -839,7 +839,7 @@ function wordpoints_delete_user_ranks( $user_id ) {
 		$wpdb->wordpoints_user_ranks
 		, array(
 			'user_id' => $user_id,
-			'blog_id' => $wpdb->blogid,
+			'blog_id' => get_current_blog_id(),
 			'site_id' => $wpdb->siteid,
 		)
 		, '%d'

--- a/tests/phpunit/tests/ranks/classes/ranks/query.php
+++ b/tests/phpunit/tests/ranks/classes/ranks/query.php
@@ -29,7 +29,7 @@ class WordPoints_User_Ranks_Query_Test extends WordPoints_PHPUnit_TestCase_Ranks
 
 		$query = new WordPoints_User_Ranks_Query();
 
-		$this->assertSame( $wpdb->blogid, $query->get_arg( 'blog_id' ) );
+		$this->assertSame( get_current_blog_id(), $query->get_arg( 'blog_id' ) );
 		$this->assertSame( $wpdb->siteid, $query->get_arg( 'site_id' ) );
 	}
 

--- a/tests/phpunit/tests/ranks/classes/ranks/query.php
+++ b/tests/phpunit/tests/ranks/classes/ranks/query.php
@@ -29,7 +29,7 @@ class WordPoints_User_Ranks_Query_Test extends WordPoints_PHPUnit_TestCase_Ranks
 
 		$query = new WordPoints_User_Ranks_Query();
 
-		$this->assertSame( get_current_blog_id(), $query->get_arg( 'blog_id' ) );
+		$this->assertSame( is_multisite() ? get_current_blog_id() : '0', $query->get_arg( 'blog_id' ) );
 		$this->assertSame( $wpdb->siteid, $query->get_arg( 'site_id' ) );
 	}
 

--- a/tests/phpunit/tests/ranks/update/2-4-0-alpha-4.php
+++ b/tests/phpunit/tests/ranks/update/2-4-0-alpha-4.php
@@ -189,7 +189,7 @@ class WordPoints_Ranks_2_4_0_Alpha_4_Update_Test extends WordPoints_PHPUnit_Test
 				'user_id'    => (string) $user_id,
 				'rank_id'    => (string) $another_rank_id,
 				'rank_group' => 'points_type-points',
-				'blog_id'    => is_multisite() ? (string) $wpdb->blogid : '0',
+				'blog_id'    => is_multisite() ? (string) get_current_blog_id() : '0',
 				'site_id'    => is_multisite() ? (string) $wpdb->siteid : '0',
 			)
 			, $duplicates[ $user_rank_id_1 ]
@@ -201,7 +201,7 @@ class WordPoints_Ranks_2_4_0_Alpha_4_Update_Test extends WordPoints_PHPUnit_Test
 				'user_id'    => (string) $user_id,
 				'rank_id'    => (string) $third_rank_id,
 				'rank_group' => 'points_type-points',
-				'blog_id'    => is_multisite() ? (string) $wpdb->blogid : '0',
+				'blog_id'    => is_multisite() ? (string) get_current_blog_id() : '0',
 				'site_id'    => is_multisite() ? (string) $wpdb->siteid : '0',
 			)
 			, $duplicates[ $user_rank_id_2 ]


### PR DESCRIPTION
get_current_blog_id() is more appropriate for determining the ID of the current site in most cases.
This eliminates the need for the global $wpdb in several functions and is better than the implicit
global used in admin pages.

Closes #742 