### PR TITLE
Replace deprecated site id method

### DIFF
--- a/src/classes/un/installer/base.php
+++ b/src/classes/un/installer/base.php
@@ -1710,7 +1710,7 @@ abstract class WordPoints_Un_Installer_Base {
 							AND `site_id` = %d
 					"
 					, $option
-					, $wpdb->siteid
+					, get_current_network_id()
 				)
 			); // WPCS: cache pass.
 

--- a/src/classes/uninstaller/options/wildcards/network.php
+++ b/src/classes/uninstaller/options/wildcards/network.php
@@ -49,7 +49,7 @@ class WordPoints_Uninstaller_Options_Wildcards_Network implements WordPoints_Rou
 						AND `site_id` = %d
 				"
 				, $this->option_name_pattern
-				, $wpdb->siteid
+				, get_current_network_id()
 			)
 		); // WPCS: cache pass.
 

--- a/src/components/points/includes/class-wordpoints-points-logs-query.php
+++ b/src/components/points/includes/class-wordpoints-points-logs-query.php
@@ -166,7 +166,7 @@ class WordPoints_Points_Logs_Query extends WordPoints_DB_Query {
 	 *        @type string       $blog_id__compare    Comparison operator for $text. May be any of these:  '=', '<>', '!=', 'LIKE', 'NOT LIKE'. Default is 'LIKE'.
 	 *        @type int[]        $blog_id__in         Limit results to these blogs.
 	 *        @type int[]        $blog_id__not_in     Exclude these blogs.
-	 *        @type int          $site_id             Limit results to this network. Default is $wpdb->siteid (current network). There isn't currently
+	 *        @type int          $site_id             Limit results to this network. Default is get_current_network_id() (current network). There isn't currently
 	 *                                                a use for this one, but its possible in future that WordPress will allow multi-network installs.
 	 *        @type string       $site_id__compare    Comparison operator for $text. May be any of these:  '=', '<>', '!=', 'LIKE', 'NOT LIKE'. Default is 'LIKE'.
 	 *        @type int[]        $site_id__in         Limit results to these sites.

--- a/src/components/points/includes/points.php
+++ b/src/components/points/includes/points.php
@@ -623,7 +623,7 @@ function wordpoints_alter_points( $user_id, $points, $points_type, $log_type, $m
 				'log_type'    => $log_type,
 				'text'        => $log_text,
 				'date'        => current_time( 'mysql', 1 ),
-				'site_id'     => $wpdb->siteid,
+				'site_id'     => get_current_network_id(),
 				'blog_id'     => is_multisite() ? get_current_blog_id() : '0',
 			),
 			array( '%d', '%d', '%s', '%s', '%s', '%s', '%d', '%d' )

--- a/src/components/ranks/classes/ranks/updater/2/4/0/user/ranks.php
+++ b/src/components/ranks/classes/ranks/updater/2/4/0/user/ranks.php
@@ -38,7 +38,7 @@ class WordPoints_Ranks_Updater_2_4_0_User_Ranks implements WordPoints_RoutineI {
 						AND `site_id` = %d
 				"
 				, is_multisite() ? get_current_blog_id() : '0'
-				, $wpdb->siteid
+				, get_current_network_id()
 			)
 		);
 

--- a/src/components/ranks/classes/user/ranks/query.php
+++ b/src/components/ranks/classes/user/ranks/query.php
@@ -78,7 +78,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 	 *        @type string       $blog_id__compare    Comparison operator for the above value.
 	 *        @type int[]        $blog_id__in         Limit results to these blogs.
 	 *        @type int[]        $blog_id__not_in     Exclude these blogs.
-	 *        @type int          $site_id             Limit results to this network. Default is $wpdb->siteid (current network). There isn't currently
+	 *        @type int          $site_id             Limit results to this network. Default is get_current_network_id() (current network). There isn't currently
 	 *                                                a use for this one, but its possible in future that WordPress will allow multi-network installs.
 	 *        @type string       $site_id__compare    Comparison operator for the above value.
 	 *        @type int[]        $site_id__in         Limit results to these sites.
@@ -98,7 +98,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 		$this->table_name = $wpdb->wordpoints_user_ranks;
 
 		$this->defaults['blog_id'] = is_multisite() ? get_current_blog_id() : '0';
-		$this->defaults['site_id'] = $wpdb->siteid;
+		$this->defaults['site_id'] = get_current_network_id();
 
 		parent::__construct( $args );
 	}
@@ -208,7 +208,7 @@ class WordPoints_User_Ranks_Query extends WordPoints_DB_Query {
 				, $rank->ID
 				, $rank->rank_group
 				, is_multisite() ? get_current_blog_id() : '0'
-				, $wpdb->siteid
+				, get_current_network_id()
 				, $rank->rank_group
 			)
 		); // WPCS: cache OK.

--- a/src/components/ranks/includes/ranks.php
+++ b/src/components/ranks/includes/ranks.php
@@ -56,7 +56,7 @@ function wordpoints_add_rank( $name, $type, $group, $position, array $meta = arr
 			'type'       => $type,
 			'rank_group' => $group,
 			'blog_id'    => is_multisite() ? get_current_blog_id() : '0',
-			'site_id'    => $wpdb->siteid,
+			'site_id'    => get_current_network_id(),
 		)
 	);
 
@@ -482,7 +482,7 @@ function wordpoints_get_user_rank( $user_id, $group ) {
 				, $user_id
 				, $group
 				, is_multisite() ? get_current_blog_id() : '0'
-				, $wpdb->siteid
+				, get_current_network_id()
 			)
 		);
 
@@ -567,7 +567,7 @@ function wordpoints_update_user_rank( $user_id, $rank_id ) {
 			, $rank_id
 			, $rank->rank_group
 			, is_multisite() ? get_current_blog_id() : '0'
-			, $wpdb->siteid
+			, get_current_network_id()
 			, $rank_id
 		)
 	);
@@ -638,7 +638,7 @@ function wordpoints_update_users_to_rank( array $user_ids, $to_rank_id, $from_ra
 		, $to_rank_id
 		, $rank->rank_group
 		, is_multisite() ? get_current_blog_id() : '0'
-		, $wpdb->siteid
+		, get_current_network_id()
 	);
 
 	$result = $wpdb->query( // WPCS: unprepared SQL OK.
@@ -813,7 +813,7 @@ function wordpoints_set_new_user_ranks( $user_id ) {
 					, $base_rank->ID
 					, $base_rank->rank_group
 					, is_multisite() ? get_current_blog_id() : '0'
-					, $wpdb->siteid
+					, get_current_network_id()
 					, $base_rank->ID
 				)
 			); // WPCS: cache OK.
@@ -840,7 +840,7 @@ function wordpoints_delete_user_ranks( $user_id ) {
 		, array(
 			'user_id' => $user_id,
 			'blog_id' => is_multisite() ? get_current_blog_id() : '0',
-			'site_id' => $wpdb->siteid,
+			'site_id' => get_current_network_id(),
 		)
 		, '%d'
 	);

--- a/tests/phpunit/tests/ranks/classes/ranks/query.php
+++ b/tests/phpunit/tests/ranks/classes/ranks/query.php
@@ -30,7 +30,7 @@ class WordPoints_User_Ranks_Query_Test extends WordPoints_PHPUnit_TestCase_Ranks
 		$query = new WordPoints_User_Ranks_Query();
 
 		$this->assertSame( is_multisite() ? get_current_blog_id() : '0', $query->get_arg( 'blog_id' ) );
-		$this->assertSame( $wpdb->siteid, $query->get_arg( 'site_id' ) );
+		$this->assertSame( get_current_network_id(), $query->get_arg( 'site_id' ) );
 	}
 
 	/**

--- a/tests/phpunit/tests/ranks/update/2-4-0-alpha-4.php
+++ b/tests/phpunit/tests/ranks/update/2-4-0-alpha-4.php
@@ -190,7 +190,7 @@ class WordPoints_Ranks_2_4_0_Alpha_4_Update_Test extends WordPoints_PHPUnit_Test
 				'rank_id'    => (string) $another_rank_id,
 				'rank_group' => 'points_type-points',
 				'blog_id'    => is_multisite() ? (string) get_current_blog_id() : '0',
-				'site_id'    => is_multisite() ? (string) $wpdb->siteid : '0',
+				'site_id'    => is_multisite() ? (string) get_current_network_id() : '0',
 			)
 			, $duplicates[ $user_rank_id_1 ]
 		);
@@ -202,7 +202,7 @@ class WordPoints_Ranks_2_4_0_Alpha_4_Update_Test extends WordPoints_PHPUnit_Test
 				'rank_id'    => (string) $third_rank_id,
 				'rank_group' => 'points_type-points',
 				'blog_id'    => is_multisite() ? (string) get_current_blog_id() : '0',
-				'site_id'    => is_multisite() ? (string) $wpdb->siteid : '0',
+				'site_id'    => is_multisite() ? (string) get_current_network_id() : '0',
 			)
 			, $duplicates[ $user_rank_id_2 ]
 		);


### PR DESCRIPTION
Replace deprecated site id method and replace with get_current_network_id()
Related to issue [724](https://github.com/WordPoints/wordpoints/issues/724)